### PR TITLE
Add railyard parser.

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -2,117 +2,227 @@
 
 // execute
 
-const deconstruct = (formula) => {
-    let TWS = formula[formula.length - 1] === " ";
-    let i = 0;
-    const main = () => {
-        let arr = [];
-        let startIndex = i;
-        const addWord = () => {
-            if ( i - 1 > startIndex ) {
-                arr.push( formula.slice( startIndex, i - 1 ) );
-            }
-        };
-        while ( i < formula.length ) {
-            switch( formula[ i++ ] ) {
-                case " ":
-                    addWord();
-                    startIndex = i;
-                    continue;
-                case "(":
-                    arr.push( main() );
-                    startIndex = i;
-                    continue;
-                case ")":
-                    addWord();
-                    return arr;
-            }
+const operators = new Map();
+operators.set("+", {
+    precedence: 1,
+    arity: 2,
+    associativity: "left",
+    fn: ( left, right ) => left + right,
+});
+operators.set("-", {
+    precedence: 1,
+    arity: 2,
+    associativity: "left",
+    fn: ( left, right ) => left - right,
+});
+operators.set("*", {
+    precedence: 2,
+    arity: 2,
+    associativity: "left",
+    fn: ( left, right ) => left * right,
+});
+operators.set("/", {
+    precedence: 2,
+    arity: 2,
+    associativity: "left",
+    fn: ( left, right ) => left / right,
+});
+
+function strToToken(token) {
+    if(operators.has(token))
+        return { type: "op", value: token };
+
+    const nval = parseFloat(token);
+    if(!isNaN(nval))
+        return { type: "number", value: nval };
+
+    return { type: "name", value: token };
+}
+
+function tokenize(str) {
+    const tokens = [];
+    let token = ""
+    for(let index = 0; index < str.length; index++){
+        const char = str[index];
+        switch(char){
+        case " ":
+            if(token !== "")
+                tokens.push(strToToken(token));
+            token = ""; 
+            break;
+        case "(":
+            if(token !== "")
+                tokens.push(strToToken(token));
+            tokens.push({ type: "paren", value: "(" });
+            token = "";
+            break;
+        case ")":
+            if(token !== "")
+                tokens.push(strToToken(token));
+            tokens.push({ type: "paren", value: ")" });
+            token = "";
+            break;
+        default:
+            token += char;
+            break;
         }
-        if( !TWS ){
-            i = i + 1;
-            addWord();
+    }
+
+    if(token !== "")
+        tokens.push(strToToken(token));
+
+    return tokens;
+}
+
+function * parseToRPN(tokens, implicitMultiply){
+    const stack = [];
+
+    let expect = "value";
+
+    const handle_op = function * (token){
+
+        const { precedence: tok_p } = operators.get(token.value);
+
+        while(true){
+            // while ((the operator at the top of the operator stack has equal precedence and is left associative))
+            //        or (there is an operator at the top of the operator stack with greater precedence))
+            //       and (the operator at the top of the operator stack is not a left bracket):
+            const top = stack[stack.length-1];
+            if(top && top.value !== "("){
+                const { precedence: top_p, associativity: top_a } = operators.get(top.value);
+                if(top_p > tok_p || (top_p === tok_p && top_a === "left")){ 
+                    //pop operators from the operator stack onto the output queue.
+                    yield stack.pop();
+                    continue;
+                }
+            }
+            break;
         }
-        return arr;
+
+        stack.push(token); // push it onto the operator stack.
     };
-    return main();
-};
 
-const allowedOperations = [
-    '+', '-', '*', '/'
-];
+    for(const token of tokens){ // while there are tokens to be read, read a token.
+        if(token.type === "number" || token.type === "name") { //if the token is a number, then:
+            if(expect !== "value"){
+                if(implicitMultiply) yield * handle_op({type: "op", name: "*"});
+                else throw new Error("Missing Operator");
+            }
+            yield token; //push it to the output queue.
+            expect = "op";
+        } else if(token.type === "op"){ //if the token is an operator, then:
+            if(expect !== "op") throw new Error("Missing Value");
+            yield * handle_op(token);
+            expect = "value";
+        } else if(token.value === "(") { // if the token is a left bracket (i.e. "("), then:
+            if(expect !== "value"){
+                if(implicitMultiply) yield * handle_op({type: "op", name: "*"});
+                else throw new Error("Missing Operator");
+            }
+            stack.push(token); // push it onto the operator stack.
+        } else if(token.value === ")") { // if the token is a right bracket (i.e. ")"), then:
+            if(expect !== "op") throw new Error("Missing Value");
+            match_parens: if(stack.length){
+                while(stack[stack.length-1].value !== "(") { // while the operator at the top of the operator stack is not a left bracket:
+                    yield stack.pop(); // pop the operator from the operator stack onto the output queue.
+                    if(stack.length === 0) break match_parens;
+                }
 
-const calculate = {
-    '+': ( left, right ) => left + right,
-    '-':( left, right ) => left - right,
-    '*':( left, right ) => left * right,
-    '/':( left, right ) => left / right
-};
+                stack.pop(); // pop the left bracket from the stack.
+                continue;
+            }
+            /* if the stack runs out without finding a left bracket, then there are mismatched parentheses. */
+            throw new Error("Mismatched Parentheses");
+        }
+    }
 
+    //if there are no more tokens to read:
+    while(stack.length){ // while there are still operator tokens on the stack:
+        const token = stack.pop();
+        if(token.type === "paren"){ /* if the operator token on the top of the stack is a bracket, then there are mismatched parentheses. */
+            throw new Error("Mismatched Parentheses");
+        }
+        
+        yield token;
+    }
+}
+
+function tokToNum(token, logError){
+    if(token.type === "name"){
+        const element = token.value;
+        if( appliedConditions && appliedConditions[element] !== void 0 &&
+            conditions && conditions[element] !== void 0){
+            return conditions[element]
+        } else {
+            const error = `Required Parameter Missing ${appliedConditions[element].name}`;
+            logError( error );
+            return NaN;
+        }
+    } else { // literal number
+        return token.value;
+    }
+}
+
+function evaluateRPNStack(q, logError){
+    const vstack = [];
+    for(const token of q){
+        if(token.type === "op"){
+            const opInfo = operators.get(token.value);
+            if(vstack.length < opInfo.arity){
+                logError("Missing Values");
+                return NaN;
+            }
+            const right = tokToNum(vstack.pop(), logError);
+            const left = tokToNum(vstack.pop(), logError);
+            vstack.push({ type: "number", value: opInfo.fn(left, right) });
+        } else {
+            vstack.push(token);
+        }
+    }
+
+    if(vstack.length > 1){
+        logError("Missing Operators");
+        return NaN;
+    }
+
+    return vstack[0].value;
+}
+
+function execute(formula, implicitMultiply, logError){
+    const tokens = tokenize(formula);
+    if(tokens.length === 0){
+        logError("Empty Formula");
+        return NaN;
+    }
+    
+    try{
+        const q = parseToRPN(tokens, implicitMultiply);
+        return evaluateRPNStack(q, logError);
+    }catch(e){
+        logError(e.message);
+        return NaN;
+    }
+}
 
 module.exports = (function( formula, conds, params ){
     const appliedConditions = this.appliedConditions || conds;
     const conditions = this.conditions || params;
-    let errors;
+    let errors = []
 
     const addToErrors = ( message ) => {
-        if( !errors ) errors = [];
         if( !errors.includes( message ) ){
             errors.push( message );
         }
     };
 
-
-    const executeAll = (elements) => {
-        let result = null,
-            operation = null,
-            error = null;
-        const execute = ( element ) => {
-            if( Array.isArray(element) ){
-                let executed = executeAll( element );
-                if( executed !== null && !isNaN( executed ) ) {
-                    result = ( result || 0 )  + executed;
-                }
-                return result;
-            }
-            if( allowedOperations.includes( element ) ){
-                return operation = element;
-            }
-            if(isNaN( element )){
-                if( appliedConditions && appliedConditions[element] !== undefined &&
-                    conditions && conditions[element] !== undefined){
-                    element = conditions[element]
-                } else {
-                    error = `Required Parameter Missing ${appliedConditions[element].name}`;
-                    addToErrors( error );
-                }
-            } else {
-                element = JSON.parse(element);
-            }
-            if( !operation ) {
-                result = element;
-            } else {
-                result = calculate[ operation ]( result, element )
-            }
-        };
-
-        elements.map( element => {
-            execute( element )
-        });
-
-        if( error ){
-            return null;
-        }
-        return result;
-    };
-
-    const formulaElements = deconstruct(formula);
-
-    const all = executeAll( formulaElements );
+    const result = execute(formula, false, addToErrors); // no implicit multiplication
+    
     if( errors ){
         if( this.addError ) errors.map( error => {
             this.addError( error );
         });
         return formula;
     }
-    return all;
+
+    return result;
 });

--- a/test/rule-evaluator/evaluate/index.js
+++ b/test/rule-evaluator/evaluate/index.js
@@ -1,5 +1,5 @@
 const Evaluator = require('../../../index');
-const expected = require('./expected-results');
+const expected = JSON.parse(require('./expected-results'));
 const assert = require('assert');
 const assocObj = require('../../associationObject');
 
@@ -16,7 +16,6 @@ module.exports = () => {
 
     const evaluated = evaluator.evaluate( ruleId, conditions );
 
-
-    assert.equal( expected, JSON.stringify(evaluated) );
+    assert.equal( JSON.stringify(expected.value), JSON.stringify(evaluated.value) );
     console.log('RE --- evaluateRule ---> Success!!!!!!!!!');
 };

--- a/test/rule/evaluate/index.js
+++ b/test/rule/evaluate/index.js
@@ -1,5 +1,5 @@
 const Evaluator = require('../../../index');
-const expected = require('./expected-results');
+const expected = JSON.parse(require('./expected-results'));
 const assert = require('assert');
 const assocObj = require('../../associationObject');
 
@@ -18,7 +18,6 @@ module.exports = () => {
 
     const evaluated = ruleEvaluator.evaluate( conditions );
 
-
-    assert.equal( expected, JSON.stringify(evaluated) );
+    assert.equal( JSON.stringify(expected.value), JSON.stringify(evaluated.value) );
     console.log('RULE --- evaluateRule ---> Success!!!!!!!!!');
 };


### PR DESCRIPTION
This is a fairly standard algorithm for parsing arithmetic expressions, with the grammar implicit in the algorithm definition. It is heavily commented so you can associate lines of JS code with the algorithm-defining psuedo-code that can be found in various reference works. It works by converting parenthesized infix notation into RPN notation, verifying the input structure along the way; RPN is easy to verify for proper argument / operator matchups, and trivial to evaluate. (It would also be trivial to return a fully-parenthesized expression tree to feed into the previous evaluator, but that seemed like an unnecessary extra step that did not need to be kept around anymore.)

The parser acts as a generator, spitting out RPN terms to be evaluated concurrently with parsing. (You can't always do that with a generic parser, but arithmetic expressions happen to have convenient properties that make this possible.)

Additional operators, like the right-associative exponentiation operator, can be added trivially, and there's a boolean switch you can flip to implement implicit multiplication by juxtaposing parenthesized terms (currently turned off). There is a standard extension you can look up on wikipedia (or elsewhere) for handling functions with arbitrary numbers of arguments, but I didn't include that because it seems like unnecessary extra complexity that wouldn't be used Right Now.

To paraphrase Donald Knuth, beware of bugs in the below code; I have only proved it correct and verified against your automated test suite, not tried it in real-world scenarios. So, I'd advise doing whatever normal testing you do in the UI to verify that it doesn't break anything, in addition to improving the handling of formulas like it's supposed to do, before taking the leap of releasing it.